### PR TITLE
Fix active state of link color for dark theme

### DIFF
--- a/webext-base.css
+++ b/webext-base.css
@@ -118,9 +118,9 @@ textarea {
 		color: var(--in-content-link-color, #8ab4f8);
 	}
 
-        a:active {
-                color: #b6d3f9;
-        }
+	a:active {
+		color: #b6d3f9;
+	}
 
 	input[type='number'],
 	input[type='password'],

--- a/webext-base.css
+++ b/webext-base.css
@@ -118,6 +118,10 @@ textarea {
 		color: var(--in-content-link-color, #8ab4f8);
 	}
 
+        a:active {
+                color: #b6d3f9;
+        }
+
 	input[type='number'],
 	input[type='password'],
 	input[type='search'],

--- a/webext-base.css
+++ b/webext-base.css
@@ -115,11 +115,11 @@ textarea {
 	}
 
 	a {
-		color: var(--in-content-link-color, #8ab4f8);
+		color: var(--link-color, #8ab4f8);
 	}
 
 	a:active {
-		color: #b6d3f9;
+		color: var(--link-color-active, #b6d3f9);
 	}
 
 	input[type='number'],


### PR DESCRIPTION
Currently, when you click on a link in a dark theme, it becomes too dark:

![image](https://github.com/fregante/webext-base-css/assets/19418601/3eeca78f-aa35-4d37-863c-c7d0058f1b53)

Made it lighter:

![image](https://github.com/fregante/webext-base-css/assets/19418601/3dabf2e7-a9ec-4018-924a-28927227d492)
