### PR TITLE
Rewrite, barebones style, MV3 compatibility 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,7 @@
 	"manifest_version": 2,
 	"version": "0.0.0",
 	"options_ui": {
-		"page": "options.html",
-		"chrome_style": true
+		"page": "options.html"
 	},
 	"background": {
 		"scripts": ["background.js"]

--- a/options.html
+++ b/options.html
@@ -5,7 +5,7 @@
 	<link rel="stylesheet" href="webext-base.css">
 </head>
 
-<h1>Heading</h1>
+<h1>Heading 🤝</h1>
 
 <p>
 	Lorem ipsum dolor sit, amet consectetur adipisicing elit. Enim ullam
@@ -59,7 +59,7 @@
 	</label>
 </p>
 
-<h4>Heading 4</h4>
+<h3>Heading 3</h3>
 
 <p>
 	<label>
@@ -72,7 +72,7 @@
 	</label>
 </p>
 
-<h5>Heading 5</h5>
+<h3>Heading 3</h3>
 
 <p>
 	<label>
@@ -85,7 +85,7 @@
 	</label>
 </p>
 
-<h6>Heading 6</h6>
+<h3>Heading 3</h3>
 
 <p>
 	<label>
@@ -97,7 +97,7 @@
 	</label>
 </p>
 
-<h6>And beyond</h6>
+<h3>Heading 3</h3>
 
 <p>
 	<button>Click me</button> or <a href="https://example.com">here</a> but definitely not <button disabled>not here</button>.

--- a/options.html
+++ b/options.html
@@ -2,11 +2,6 @@
 <head>
 	<meta charset="utf-8">
 	<title>Demo</title>
-	<style>
-		/* These 2 are for local testing only, do not use, they're normally added by browser_style */
-		@import 'chrome://browser/content/extension.css';
-		@import 'chrome://browser/content/extension-mac.css';
-	</style>
 	<link rel="stylesheet" href="webext-base.css">
 </head>
 
@@ -14,7 +9,10 @@
 
 <p>
 	Lorem ipsum dolor sit, amet consectetur adipisicing elit. Enim ullam
-	asperiores eum quo? Debitis esse quasi consequuntur voluptates! Ex
+	asperiores eum quo? S<kbd>kbd</kbd>-<kbd>toilet</kbd>
+</p>
+<hr>
+<p> Debitis esse quasi consequuntur voluptates! Ex
 	exercitationem optio voluptatibus at nisi labore praesentium dignissimos porro
 	soluta asperiores!
 </p>
@@ -29,9 +27,20 @@
 			type="text"
 			spellcheck="false"
 			autocomplete="off"
-			placeholder="input[type=text]"
+			placeholder="input[type=text][size=20]"
 			required
 			pattern="\d"
+			size="20"
+		/>
+	</label>
+</p>
+
+<p>
+	<label>
+		<strong>Unlimited type-less one-liner:</strong><br>
+		<input
+			name="my-limited-text"
+			placeholder="input"
 		/>
 	</label>
 </p>
@@ -86,4 +95,10 @@
 			<option value="∞">Last</option>
 		</select>
 	</label>
+</p>
+
+<h6>And beyond</h6>
+
+<p>
+	<button>Click me</button> or <a href="https://example.com">here</a> but definitely not <button disabled>not here</button>.
 </p>

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,17 @@ Here's a minimal but full `options.html` example page:
 <script src="options.js"></script>
 ```
 
+## Extras
+
+There are some extra classes you can use:
+
+- `.monospace-field` for `<input>` and `<textarea>` to have a monospace font
+
+## Tips
+
+- Use the `<input size="10">` to define the width of `input` fields, or else they're now set to `100%` by default.
+- Use `<link rel="stylesheet" href="chrome://global/skin/in-content/common.css">` if you want to use Firefox's native style, but this means you'll have to handle the inconsistencies between web browsers. This used to be included in <code>webext-base-css</code> v1.
+
 ## Related
 
 - [webext-storage-cache](https://github.com/fregante/webext-storage-cache) - Map-like promised cache storage with expiration. Chrome and Firefox

--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,6 @@
 
 > Extremely minimal "native" stylesheet/setup for Web Extensions’ options pages (also dark mode)
 
-Together with some stylesheets included by the browsers, extends and improves the the `options_ui.chrome_style` setting, including Firefox.
-
 It's meant to look as _native_ as possible, _invisible_. `webext-base-css` is what browsers should offer by default.
 
 Look at the demo [options.html](options.html) for the suggested markup (it's basic and not really enforced.)
@@ -30,13 +28,12 @@ npm install webext-base-css
 <link rel="stylesheet" href="your-own-stylesheet-if-necessary.css">
 ```
 
-You'll also have to set `chrome_style: true` in your manifest.json:
+And in your manifest.json:
 
 ```json
 {
 	"options_ui": {
 		"page": "options.html",
-		"chrome_style": true
 	}
 }
 ```

--- a/webext-base.css
+++ b/webext-base.css
@@ -1,57 +1,34 @@
 /*! https://npm.im/webext-base-css */
 
-/* Firefox only: @-moz-document */
-/* Firefox only: var(--in-content-*) */
-/* Chrome only: -webkit-hyphens */
-/* Safari only: _::-webkit-full-page-media */
-
-/* webpackIgnore: true */
-@import url('chrome://global/skin/in-content/common.css') (min--moz-device-pixel-ratio:0); /* Firefox-only */
-
 :root {
-	--background-color-for-chrome: #292a2d;
 	max-width: 700px;
 	margin: auto;
+	font:
+		1em/1.5 -apple-system,
+		BlinkMacSystemFont,
+		sans-serif,
+		'Apple Color Emoji';
 }
 
-body {
-	--body-margin-h: 8px;
-	margin-left: var(--body-margin-h);
-	margin-right: var(--body-margin-h);
-}
-
-/* Selector matches Firefox’ */
-input[type='number'],
-input[type='password'],
-input[type='search'],
-input[type='text'],
-input[type='url'],
-input:not([type]),
-textarea {
-	display: block;
-	box-sizing: border-box;
-	margin-left: 0;
+input:where(
+        [type='number'],
+        [type='password'],
+        [type='search'],
+        [type='text'],
+        [type='url'],
+        :not([type])
+):not([size]) {
 	width: 100%;
-	resize: vertical;
-	-moz-tab-size: 4 !important;
-	tab-size: 4 !important;
+	box-sizing: border-box;
+	line-height: 2;
 }
 
-input[type='checkbox'] {
-	vertical-align: -0.15em;
-}
-
-@supports (not (-webkit-hyphens:none)) and (not (-moz-appearance:none)) and (list-style-type:'*') {
-	textarea:focus {
-		/* Inexplicably missing from Chrome’s input style https://github.com/chromium/chromium/blob/6bea0557fe/extensions/renderer/resources/extension.css#L287 */
-		border-color: #4d90fe;
-		transition: border-color 200ms;
-	}
+textarea {
+	width: 100%;
+	box-sizing: border-box;
 }
 
 hr {
-	margin-right: calc(-1 * var(--body-margin-h));
-	margin-left: calc(-1 * var(--body-margin-h));
 	border: none;
 	border-bottom: 1px solid #aaa4;
 }
@@ -60,76 +37,15 @@ img {
 	vertical-align: middle;
 }
 
-_::-webkit-full-page-media,
-_:future,
-:root {
-	font-family: -apple-system, BlinkMacSystemFont, sans-serif, 'Apple Color Emoji';
-}
-
-_::-webkit-full-page-media,
-_:future,
-input[type='number'],
-input[type='password'],
-input[type='search'],
-input[type='text'],
-input[type='url'],
-input:not([type]),
-textarea {
-	border: solid 1px #888;
-	padding: 0.4em;
-	font: inherit;
-	-webkit-appearance: none;
-}
-
-@-moz-document url-prefix('') {
-	:root, /* Visible on a options_page */
-	body {
-		--body-margin-h: 6px; /* Must be a variable so <hr>’s margin is changed too */ /* Visible on a options_page and options_ui */
-		color: var(--in-content-page-color);
-
-		/* Also supports dark themes in Firefox */
-		/* !important is to override the dark-mode setting for Chrome below */
-		background-color: var(--in-content-box-background) !important;
-		min-height: 250px; /* Without this there’s a white space at the bottom in dark mode */
-	}
-
-	body > * {
-		margin-left: var(--body-margin-h);
-		margin-right: var(--body-margin-h);
-	}
-
-	input[type='checkbox'] {
-		vertical-align: -0.4em;
-	}
-}
-
-@media (prefers-color-scheme: dark) {
-	:root {
-		color-scheme: dark;
-		background-color: var(--background-color-for-chrome);
-	}
-
-	body,
-	h3 { /* Chrome #3 */
-		color: var(--in-content-page-color, #e8eaed);
-	}
-
-	a {
-		color: var(--link-color, #8ab4f8);
-	}
-
-	a:active {
-		color: var(--link-color-active, #b6d3f9);
-	}
-
-	input[type='number'],
-	input[type='password'],
-	input[type='search'],
-	input[type='text'],
-	input[type='url'],
-	input:not([type]),
-	textarea {
-		color: inherit;
-		background-color: transparent;
-	}
+kbd {
+	display: inline-block;
+	padding: 3px 5px;
+	font-size: 0.8em;
+	line-height: 10px;
+	color: #444d56;
+	vertical-align: middle;
+	background-color: #fafbfc;
+	border: 1px solid #d1d5da;
+	border-radius: 6px;
+	box-shadow: inset 0 -1px 0 #d1d5da;
 }

--- a/webext-base.css
+++ b/webext-base.css
@@ -84,3 +84,14 @@ kbd {
 	}
 }
 
+.monospace-field {
+	/* Same as GitHub style for `code` */
+	font-family:
+		ui-monospace,
+		SFMono-Regular,
+		'SF Mono',
+		Menlo,
+		Consolas,
+		'Liberation Mono',
+		monospace !important;
+}

--- a/webext-base.css
+++ b/webext-base.css
@@ -4,43 +4,58 @@
 	color-scheme: light dark;
 	max-width: 700px;
 	margin: auto;
-	font:
-		16px/1.5 -apple-system,
-		BlinkMacSystemFont,
-		sans-serif,
-		'Apple Color Emoji';
+}
+
+body {
+	/* Must be on body because both browsers have `font-size: 75%` here */
+	font: 16px/1.5 system-ui, sans-serif;
 }
 
 
+select,
+textarea,
 input:where(
-[type='number'],
-[type='password'],
-[type='search'],
-[type='text'],
-[type='url'],
-:not([type])
+	[type='number'],
+	[type='password'],
+	[type='search'],
+	[type='text'],
+	[type='url'],
+	:not([type])
 ) {
 	box-sizing: border-box;
-	font-size: 1em;
+	font: inherit;
 	line-height: 2;
 }
 
+textarea,
 input:where(
-[type='number'],
-[type='password'],
-[type='search'],
-[type='text'],
-[type='url'],
-:not([type])
-):not([size]),
-textarea {
+	[type='number'],
+	[type='password'],
+	[type='search'],
+	[type='text'],
+	[type='url'],
+	:not([type])
+):not([size]) {
 	width: 100%;
+}
+
+textarea {
+	line-height: 1.5; /* Reset it because 2 is too big */
+	resize: vertical;
+	min-height: 3lh;
+	/* stylelint-disable-next-line property-no-unknown */
+	field-sizing: content;
+}
+
+input[type='submit'],
+button {
+	font: inherit;
 }
 
 hr {
 	border: none;
-	border-bottom: 1px solid currentColor;
-	opacity: 0.5;
+	border-bottom: 1px solid currentcolor;
+	opacity: 50%;
 }
 
 img {

--- a/webext-base.css
+++ b/webext-base.css
@@ -1,36 +1,46 @@
 /*! https://npm.im/webext-base-css */
 
 :root {
+	color-scheme: light dark;
 	max-width: 700px;
 	margin: auto;
 	font:
-		1em/1.5 -apple-system,
+		16px/1.5 -apple-system,
 		BlinkMacSystemFont,
 		sans-serif,
 		'Apple Color Emoji';
 }
 
+
 input:where(
-        [type='number'],
-        [type='password'],
-        [type='search'],
-        [type='text'],
-        [type='url'],
-        :not([type])
-):not([size]) {
-	width: 100%;
+[type='number'],
+[type='password'],
+[type='search'],
+[type='text'],
+[type='url'],
+:not([type])
+) {
 	box-sizing: border-box;
+	font-size: 1em;
 	line-height: 2;
 }
 
+input:where(
+[type='number'],
+[type='password'],
+[type='search'],
+[type='text'],
+[type='url'],
+:not([type])
+):not([size]),
 textarea {
 	width: 100%;
-	box-sizing: border-box;
 }
 
 hr {
 	border: none;
-	border-bottom: 1px solid #aaa4;
+	border-bottom: 1px solid currentColor;
+	opacity: 0.5;
 }
 
 img {
@@ -49,3 +59,13 @@ kbd {
 	border-radius: 6px;
 	box-shadow: inset 0 -1px 0 #d1d5da;
 }
+
+
+@-moz-document url-prefix('') {
+	@media (prefers-color-scheme: dark) {
+		:root {
+			background-color: #23222b;
+		}
+	}
+}
+


### PR DESCRIPTION
Since `chrome_style` was deprecated and `color-scheme: light dark` brings native dark mode, the style needed is nearly nothing. 

The major inconsistency is that Chrome sets a sans-serif font as default while Firefox still uses Times.

Also for now I'm dropping the idea of "blending in" in the `options_ui` page. I've come to think that they're really poor ways to display any non-trivial option, so I'll come up with a better generic solution for `options_page` instead.

- Closes https://github.com/fregante/webext-base-css/issues/10
- Closes https://github.com/fregante/webext-base-css/issues/14
- Closes https://github.com/fregante/webext-base-css/issues/11
- Closes https://github.com/fregante/webext-base-css/issues/16